### PR TITLE
Fix build failure on deepin-riscv

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
-dbus-c++ (0.9.0-9) UNRELEASED; urgency=medium
+dbus-c++ (0.9.0-10) unstable; urgency=medium
 
-  * update
+  * QA upload.
+  * Add 08_fix_gcc-12.patch, taken from Fedora. Closes: #1012911
 
- -- Debian QA Group <packages@qa.debian.org>  Thu, 19 May 2022 10:17:53 +0800
+ -- Håvard F. Aasen <havard.f.aasen@pfft.no>  Sun, 24 Jul 2022 09:17:58 +0200
 
 dbus-c++ (0.9.0-9) unstable; urgency=medium
 

--- a/debian/patches/08_fix_gcc-12.patch
+++ b/debian/patches/08_fix_gcc-12.patch
@@ -1,0 +1,90 @@
+From: Peter Williams <peter@newton.cx>
+Date: Sat, 19 Dec 2015 21:12:46 -0500
+Subject: Fix some weird template/operator issues on OS X.
+
+I frankly don't understand at all what's going on here. These fixes
+derive from:
+
+https://chromium.googlesource.com/chromiumos/third_party/dbus-cplusplus/+/c3f69f6be02e31521474dce7eadf6ba4f4a7ce94
+https://chromium.googlesource.com/chromiumos/third_party/dbus-cplusplus/+/7104857773f790a549d399715482fa23d9b736cd
+
+Except I've dropped some changes that break the OS X build for me. Frankly, if
+it compiles, that's good enough for me.
+---
+ include/dbus-c++/types.h | 23 ++++++++++++++---------
+ src/types.cpp            |  3 ++-
+ 2 files changed, 16 insertions(+), 10 deletions(-)
+
+diff --git a/include/dbus-c++/types.h b/include/dbus-c++/types.h
+index 044e72b..7b3108f 100644
+--- a/include/dbus-c++/types.h
++++ b/include/dbus-c++/types.h
+@@ -89,13 +89,7 @@ public:
+   }
+ 
+   template <typename T>
+-  operator T() const
+-  {
+-    T cast;
+-    MessageIter ri = _msg.reader();
+-    ri >> cast;
+-    return cast;
+-  }
++  operator T() const;
+ 
+ private:
+ 
+@@ -316,7 +310,7 @@ struct type< Struct<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14,
+   }
+ };
+ 
+-} /* namespace DBus */
++extern DXXAPI DBus::MessageIter &operator << (DBus::MessageIter &iter, const DBus::Variant &val);
+ 
+ inline DBus::MessageIter &operator << (DBus::MessageIter &iter, const DBus::Invalid &)
+ {
+@@ -551,6 +545,8 @@ inline DBus::MessageIter &operator >> (DBus::MessageIter &iter, DBus::Signature
+   return ++iter;
+ }
+ 
++extern DXXAPI DBus::MessageIter &operator >> (DBus::MessageIter &iter, DBus::Variant &val);
++
+ template<typename E>
+ inline DBus::MessageIter &operator >> (DBus::MessageIter &iter, std::vector<E>& val)
+ {
+@@ -644,7 +640,16 @@ inline DBus::MessageIter &operator >> (DBus::MessageIter &iter, DBus::Struct<T1,
+   return ++iter;
+ }
+ 
+-extern DXXAPI DBus::MessageIter &operator >> (DBus::MessageIter &iter, DBus::Variant &val);
++template <typename T>
++inline DBus::Variant::operator T() const
++{
++  T cast;
++  DBus::MessageIter ri = _msg.reader();
++  ri >> cast;
++  return cast;
++}
++
++} /* namespace DBus */
+ 
+ #endif//__DBUSXX_TYPES_H
+ 
+diff --git a/src/types.cpp b/src/types.cpp
+index d414a3e..70f9ac0 100644
+--- a/src/types.cpp
++++ b/src/types.cpp
+@@ -34,7 +34,7 @@
+ #include "message_p.h"
+ #include "internalerror.h"
+ 
+-using namespace DBus;
++namespace DBus {
+ 
+ Variant::Variant()
+   : _msg(CallMessage()) // dummy message used as temporary storage for variant data
+@@ -104,3 +104,4 @@ MessageIter &operator >> (MessageIter &iter, Variant &val)
+   return ++iter;
+ }
+ 
++} /* namespace DBus */

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@
 05_fix_glibmm_ftbfs.patch
 06_fix_gcc-7_ftbfs.patch
 07_fix_mutex_ftbfs.patch
+08_fix_gcc-12.patch


### PR DESCRIPTION
Sync from upstream to avoid build failure caused by gcc12.